### PR TITLE
throttling: add a noauth zone

### DIFF
--- a/etc/nginx/sites-available/wazo
+++ b/etc/nginx/sites-available/wazo
@@ -4,6 +4,11 @@ log_format main
     '$request_length $msec $request_time $upstream_addr '
     '$upstream_response_length $upstream_response_time $upstream_status';
 
+# The noauth zone is meant to be applied to ressources that are unauthenticated
+# Limits are applied to each individual IP addresses. Be careful with this limit
+# a single IP address could be used by many users.
+limit_req_zone $binary_remote_addr zone=noauth:10m rate=25r/s;
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;

--- a/etc/nginx/wazo-no-auth-shared.conf
+++ b/etc/nginx/wazo-no-auth-shared.conf
@@ -1,0 +1,6 @@
+# The resources will use the noauth IP address zone which is defined
+# in the wazo-nginx repository.
+limit_req zone=noauth;
+
+# When the limit is reached a 429 will be returned to the caller
+limit_req_status 429;


### PR DESCRIPTION
The noauth zone should be used on any resource that is not authenticated. The
limit is by IP and a maximum of 10Mb is used for the state of this zone.

The rate limit is 15 request/seconds. Futher requests will receive a 429
response.

The "wazo-no-auth-shared.conf" rules can be included in any location using the
include directive.

include /etc/nginx/wazo-no-auth-shared.conf;