### PR TITLE
throttling: fix bursting

### DIFF
--- a/etc/nginx/wazo-no-auth-shared.conf
+++ b/etc/nginx/wazo-no-auth-shared.conf
@@ -1,6 +1,6 @@
 # The resources will use the noauth IP address zone which is defined
 # in the wazo-nginx repository.
-limit_req zone=noauth;
+limit_req zone=noauth burst=15 nodelay;
 
 # When the limit is reached a 429 will be returned to the caller
 limit_req_status 429;


### PR DESCRIPTION
Why: we need some form of bursting to enable the OPTIONS
to not cause too many requests per second