### PR TITLE
WAZO-2791 Improve Wazo nginx security

### DIFF
--- a/etc/nginx/sites-available/wazo
+++ b/etc/nginx/sites-available/wazo
@@ -18,7 +18,7 @@ server {
     error_log /var/log/nginx/wazo.error.log;
     root /var/www/html;
 
-    include /etc/nginx/locations/http-enabled/*;
+    return 301 https://$host$request_uri;
 }
 
 server {
@@ -38,5 +38,6 @@ server {
     ssl_certificate /usr/share/xivo-certs/server.crt;
     ssl_certificate_key /usr/share/xivo-certs/server.key;
     ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:!SEED:+HIGH:+MEDIUM;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 }

--- a/etc/nginx/sites-available/wazo
+++ b/etc/nginx/sites-available/wazo
@@ -39,5 +39,5 @@ server {
     ssl_certificate_key /usr/share/xivo-certs/server.key;
     ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:!SEED:+HIGH:+MEDIUM;
     ssl_protocols TLSv1.2 TLSv1.3;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+    add_header Strict-Transport-Security "max-age=31536000";
 }


### PR DESCRIPTION
Hello,

This PR enforces nginx security, doing 3 things.

It forces HTTP to HTTPS redirection.

It disables old / unsecure TLSv1.0 and TLSv1.1 protocols, and enables "new" TLSv1.3.
https://blog.qualys.com/product-tech/2018/11/19/grade-change-for-tls-1-0-and-tls-1-1-protocols

It adds now common / widely used Strict-Transport-Security headers.

All this makes Wazo more secure.
As a result, ssllabs.com note improves from B to A+.

Of course tested, no production impact.

Ref : Wazo ticket #5677.

Thank you very much :+1: