### PR TITLE
fix deprecated warning about ssl config

### DIFF
--- a/etc/nginx/sites-available/wazo
+++ b/etc/nginx/sites-available/wazo
@@ -29,8 +29,8 @@ server {
 }
 
 server {
-    listen 443 default_server;
-    listen [::]:443 default_server;
+    listen 443 default_server ssl;
+    listen [::]:443 default_server ssl;
     server_name $domain;
 
     access_log /var/log/nginx/wazo.access.log main;
@@ -40,7 +40,6 @@ server {
     include /etc/nginx/locations/https-enabled/*;
 
     gzip off; # gzipping SSL encripted data is a waste of time
-    ssl on;
     fastcgi_param HTTPS on;
     ssl_certificate /usr/share/xivo-certs/server.crt;
     ssl_certificate_key /usr/share/xivo-certs/server.key;


### PR DESCRIPTION
is deprecated since nginx 1.15.0
https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl