### PR TITLE
WAZO-4174-remove-server-name

### DIFF
--- a/etc/nginx/sites-available/wazo
+++ b/etc/nginx/sites-available/wazo
@@ -19,7 +19,7 @@ limit_req_zone $binary_remote_addr zone=noauth:10m rate=25r/s;
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name $domain;
+    server_name _;
 
     access_log /var/log/nginx/wazo.access.log main;
     error_log /var/log/nginx/wazo.error.log;
@@ -31,7 +31,7 @@ server {
 server {
     listen 443 default_server ssl;
     listen [::]:443 default_server ssl;
-    server_name $domain;
+    server_name _;
 
     access_log /var/log/nginx/wazo.access.log main;
     error_log /var/log/nginx/wazo.error.log;


### PR DESCRIPTION
why: $domain value was used by a regex captured group long time ago ...
Now the value is a plain "$domain" string which will never match a
valid domain
The standard syntax to use in this situation is "_"
